### PR TITLE
Fix variable name in Bloatware foreach

### DIFF
--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -118,7 +118,7 @@ Function DebloatBlacklist {
     )
     foreach ($Bloat in $Bloatware) {
         Get-AppxPackage -Name $Bloat| Remove-AppxPackage -ErrorAction SilentlyContinue
-        Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $Debloat | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+        Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $Bloat | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
         Write-Output "Trying to remove $Bloat."
     }
 }


### PR DESCRIPTION
There's no variable named $Debloat. Looks like this might be a typo.