### PR TITLE
Update Windows10SysPrepDebloater.ps1

### DIFF
--- a/Windows10SysPrepDebloater.ps1
+++ b/Windows10SysPrepDebloater.ps1
@@ -25,7 +25,8 @@ Function Begin-SysPrep {
         #Stop WindowsStore Installer Service and set to Disabled
         Write-Verbose -Message ('Stopping InstallService')
         Stop-Service InstallService 
- } #>
+        #>
+ } 
 
 #Creates a PSDrive to be able to access the 'HKCR' tree
 New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT


### PR DESCRIPTION
#> is in the wrong place and creates an error 

Missing closing '}' in statement block or type definition.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingEndCurlyBrace