### PR TITLE
FIX #240 and #259

### DIFF
--- a/Windows10SysPrepDebloater.ps1
+++ b/Windows10SysPrepDebloater.ps1
@@ -176,7 +176,7 @@ Function Protect-Privacy {
      Write-Output "Removing CloudStore from registry if it exists"
      $CloudStore = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CloudStore'
      If (Test-Path $CloudStore) {
-     Stop-Process Explorer.exe -Force
+     Stop-Process -Name explorer -Force
      Remove-Item $CloudStore -Recurse -Force
      Start-Process Explorer.exe -Wait
     }


### PR DESCRIPTION
The explorer process could not be killed, because powershell cannot convert the "Explorer.exe" value of type "System.String" to type "System.Diagnostics.Process".
Description and solution in #240 . If issues still occur we could try the solution proposed in #259