### PR TITLE
Shortened quick download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Zune Video.
 
 # Quick download link
 
-`iex ((New-Object System.Net.WebClient).DownloadString('https://git.io/debloat'))`
+`iwr -useb https://git.io/debloat|iex`
 
 # Credits
 


### PR DESCRIPTION
Shortened the link so it's easier to type (if you cannot copy&paste it) and memorize