### PR TITLE
don't hide that we are doing a dot include

### DIFF
--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -195,7 +195,7 @@ Function dotInclude() {
     }
     if ( test-path $scriptPath\$includeFile ) {
         # import and immediately execute the requested file
-        .$scriptPath\$includeFile
+        . $scriptPath\$includeFile
     }
 }
 


### PR DESCRIPTION
partial revert of commit a3091bf16eaa92e70ce574fe5e08f2aaf82a8ff

The dot is not part of the path. So keep it separate visually.
That is the normal syntax that I have seen for dot includes.
Merging it into the path hides the distinctive characteristic
of a dot include (even for me who always has a dirty monitor).