### PR TITLE
Wild cards are not allowed - remove *Nvidia*  #313

### DIFF
--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -125,7 +125,6 @@ $global:WhiteListedApps = @(
     "WindSynthBerry"                            # Issue 68
     "MIDIBerry"                                 # Issue 68
     "Slack"                                     # Issue 83
-    "*Nvidia*"                                  # Issue 198
     "Microsoft.MixedReality.Portal"             # Issue 195
 )
 


### PR DESCRIPTION
Blind fix based on another bug report - but sounds right
and seems to resolve some matching/duplicate entry anomalies.

These lists are used in two different ways.
One way is a regex match which would require it to be .*Nvidia.*,
but I think the other way (non-regex) just uses *Nvidia*.