### PR TITLE
Fix OneDrive Policy

### DIFF
--- a/Windows10Debloater.ps1
+++ b/Windows10Debloater.ps1
@@ -574,9 +574,8 @@ Function UninstallOneDrive {
         $OneDriveKey = 'HKLM:Software\Policies\Microsoft\Windows\OneDrive'
         If (!(Test-Path $OneDriveKey)) {
             Mkdir $OneDriveKey
-            Set-ItemProperty $OneDriveKey -Name OneDrive -Value DisableFileSyncNGSC
         }
-        Set-ItemProperty $OneDriveKey -Name OneDrive -Value DisableFileSyncNGSC
+        Set-ItemProperty $OneDriveKey -Name DisableFileSyncNGSC -Value 1
     }
 
     Write-Host "Uninstalling OneDrive. Please wait..."

--- a/Windows10DebloaterGUI.ps1
+++ b/Windows10DebloaterGUI.ps1
@@ -1408,9 +1408,8 @@ $RemoveOnedrive.Add_Click( {
             $OneDriveKey = 'HKLM:Software\Policies\Microsoft\Windows\OneDrive'
             If (!(Test-Path $OneDriveKey)) {
                 Mkdir $OneDriveKey
-                Set-ItemProperty $OneDriveKey -Name OneDrive -Value DisableFileSyncNGSC
             }
-            Set-ItemProperty $OneDriveKey -Name OneDrive -Value DisableFileSyncNGSC
+            Set-ItemProperty $OneDriveKey -Name DisableFileSyncNGSC -Value 1
         }
 
         Write-Host "Uninstalling OneDrive. Please wait..."


### PR DESCRIPTION
Apply the "Prevent the usage of OneDrive for file storage" policy correctly. Previously, it created HKLM:Software\Policies\Microsoft\Windows\OneDrive\OneDrive="DisableFileSyncNGSC". However, the value should be HKLM:Software\Policies\Microsoft\Windows\OneDrive\DisableFileSyncNGSC=1